### PR TITLE
Prevent from rescuing uselessly

### DIFF
--- a/lib/readthis/entity.rb
+++ b/lib/readthis/entity.rb
@@ -76,8 +76,9 @@ module Readthis
     #   entity.load(dumped)
     #
     def load(string)
-      marshal, compress, value = decompose(string)
+      return if string.nil?
 
+      marshal, compress, value = decompose(string)
       marshal.load(inflate(value, compress))
     rescue TypeError, NoMethodError
       string


### PR DESCRIPTION
Rescuing is much slower than exiting early with a guard, especially when loading multiple values in bulk (cf. `read_multi`) and the cache is cold or incomplete.
